### PR TITLE
Clarify 'case 2' for 'this' explanation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ function logThis() {
 logThis(); // window
 ```
 
-### Case 2: In a method, `this` points to the object that contains the method. 
+### Case 2: In a method, `this` points to the object that calls the method. 
 
 ```javascript
 var myObject = {


### PR DESCRIPTION
Here is something I learned today.  See example below.

```
var obj = {
  hello: function() { return "hello, " + this.username; },
  username: "Kenny"
};
obj.hello(); // "hello, Kenny

var obj2 = {
  hello: obj.hello,
  username: "Gordon"
};
obj2. hello(); // "hello, Gordon"
```

Rather than saying 'contains' the method, 'calls' the method seems more accurate.